### PR TITLE
Added 4_19_test folder with various rosa-control-plane test configurations.

### DIFF
--- a/templates/4_19_tests/rcp-enable-cluster-autoscaler-expander.yaml
+++ b/templates/4_19_tests/rcp-enable-cluster-autoscaler-expander.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "capi-enable-cluster-autoscaler-expander-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "capi-enable-cluster-autoscaler-expander-test"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "capi-enable-cluster-autoscaler-expander-test"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "capi-enable-cluster-autoscaler-expander-test"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "capi-enable-cluster-autoscaler-expander-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: capi-enable-cluster-autoscaler-expander-test
+  version:  "4.19.0-ec.5"
+  region: "us-west-2"
+  channelGroup: candidate
+  domainPrefix: capi-test
+  additionalTags:
+    env: "demo"
+    profile: "hcp"
+    tagKey: "capi-tag"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 3
+  endpointAccess: Public
+  network:
+    machineCIDR: "10.0.0.0/16"
+    networkType: Other
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kms-provider"
+  oidcID: "REPLACE_ME"
+  subnets:
+    - "REPLACE_ME"
+    - "REPLACE_ME"
+  availabilityZones:
+    - "us-west-2b"
+  installerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Worker-Role"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: "default"
+spec:
+  allowedNamespaces: { }  # matches all namespaces
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: test-capa-mp
+  annotations:
+    cluster.x-k8s.io/replicas-managed-by: "external-autoscaler"
+spec:
+  clusterName: capi-enable-cluster-autoscaler-expander-test
+  replicas: 2
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfig
+          name: test-capa-mp
+      clusterName: capa
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AWSMachinePool
+        name: test-capa-mp
+      version: v1.25.0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: rosa-test-poola
+spec:
+  nodePoolName: "nodepool-0"
+  instanceType: "m5.xlarge"
+  subnet: "REPLACE_ME" # public subnet
+  version: "4.19.0-ec.5"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 2

--- a/templates/4_19_tests/rcp-external-auth.yaml
+++ b/templates/4_19_tests/rcp-external-auth.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "capi-external-auth-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "capi-external-auth-test"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "capi-external-auth-test-control-plane"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "capi-external-auth-test"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "capi-external-auth-test-control-plane"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: capi-external-auth-test
+  version:  "4.19.0-ec.5"
+  region: "us-west-2"
+  channelGroup: candidate
+  domainPrefix: capi-test4
+  additionalTags:
+    env: "demo"
+    profile: "hcp"
+    tagKey: "capi-tag"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 3
+  enableExternalAuthProviders: true
+  externalAuthProviders:
+  - name: "example"
+    issuer:
+      issuerURL: "https://example.com"
+      audiences:
+      - "example-audience"
+  endpointAccess: Public
+  network:
+    machineCIDR: "10.0.0.0/16"
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kms-provider"
+  oidcID: "REPLACE_ME"
+  subnets:
+    - "REPLACE_ME"
+    - "REPLACE_ME"
+  availabilityZones:
+    - "us-west-2b"
+  installerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Worker-Role"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: "default"
+spec:
+  allowedNamespaces: { }  # matches all namespaces
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: rosa-capi-pool
+spec:
+  nodePoolName: "nodepool-0"
+  instanceType: "m5.xlarge"
+  subnet: "REPLACE_ME" # public subnet
+  version: "4.19.0-ec.5"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 2

--- a/templates/4_19_tests/rcp-image-registry-config.yaml
+++ b/templates/4_19_tests/rcp-image-registry-config.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "capi-cluster-registry-config-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "capi-cluster-registry-config-test"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "capi-cluster-registry-config-test"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "capi-cluster-registry-config-test"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "capi-cluster-registry-config-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: capi-cluster-registry-config-test
+  version:  "4.19.0-ec.5"
+  region: "us-west-2"
+  channelGroup: candidate
+  domainPrefix: capi-test
+  additionalTags:
+    env: "demo"
+    profile: "hcp"
+    tagKey: "capi-tag"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 3
+  endpointAccess: Public
+  clusterRegistryConfig:
+    allowedRegistriesForImport:
+      - domainName: "trusted-registry.com"
+        insecure: false
+      - domainName: "*.insecure-registry.com"
+        insecure: true
+    registrySources:
+      allowedRegistries:
+        - "allowed-registry.com"
+      insecureRegistries:
+        - "insecure-registry.com"
+  network:
+    machineCIDR: "10.0.0.0/16"
+    networkType: Other
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kms-provider"
+  oidcID: "REPLACE_ME"
+  subnets:
+    - "REPLACE_ME"
+    - "REPLACE_ME"
+  availabilityZones:
+    - "us-west-2b"
+  installerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Worker-Role"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: "default"
+spec:
+  allowedNamespaces: { }  # matches all namespaces
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: rosa-capi-pool9
+spec:
+  nodePoolName: "nodepool-0"
+  instanceType: "m5.xlarge"
+  subnet: "REPLACE_ME" # public subnet
+  version: "4.19.0-ec.5"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 2

--- a/templates/4_19_tests/rcp-machine-pool-disk-size.yaml
+++ b/templates/4_19_tests/rcp-machine-pool-disk-size.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "capi-mp-disk-volume-size-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "capi-mp-disk-volume-size-test"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "capi-mp-disk-volume-size-test"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "capi-mp-disk-volume-size-test"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "capi-mp-disk-volume-size-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: capi-mp-disk-volume-size-test
+  version:  "4.19.0-ec.5"
+  region: "us-west-2"
+  channelGroup: candidate
+  domainPrefix: capi-testa
+  additionalTags:
+    env: "demo"
+    profile: "hcp"
+    tagKey: "capi-tag"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    volumeSize: 199
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 3
+  endpointAccess: Public
+  network:
+    machineCIDR: "10.0.0.0/16"
+    networkType: Other
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kms-provider"
+  oidcID: "REPLACE_ME"
+  subnets:
+    - "REPLACE_ME"
+    - "REPLACE_ME"
+  availabilityZones:
+    - "us-west-2b"
+  installerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Worker-Role"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: "default"
+spec:
+  allowedNamespaces: { }  # matches all namespaces
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: rosa-capi-poola
+spec:
+  nodePoolName: "nodepool-0"
+  volumeSize: 234
+  instanceType: "m5.xlarge"
+  subnet: "REPLACE_ME" # public subnet
+  version: "4.19.0-ec.5"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 2
+

--- a/templates/4_19_tests/rcp-multi-test.yaml
+++ b/templates/4_19_tests/rcp-multi-test.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "maryhadalittlelamblittlelamblittlelambmaryhadalit"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "maryhadalittlelamblittlelamblittlelambmaryhadalit"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "maryhadalittlelamblittlelamblittlelambmaryhadalit-control-plane"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "maryhadalittlelamblittlelamblittlelambmaryhadalit"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "maryhadalittlelamblittlelamblittlelambmaryhadalit-control-plane"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: maryhadalittlelamblittlelamblittlelambmaryhadalit
+  version:  "4.19.0-ec.5"
+  region: "us-west-2"
+  channelGroup: candidate
+  domainPrefix: capi-test
+  additionalTags:
+    env: "demo"
+    profile: "hcp"
+    tagKey: "capi-tag"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 3
+  network:
+    machineCIDR: "10.0.0.0/16"
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kms-provider"
+  oidcID: "REPLACE_ME"
+  subnets:
+    - "REPLACE_ME"
+    - "REPLACE_ME"
+  availabilityZones:
+    - "us-west-2b"
+  installerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Worker-Role"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: "default"
+spec:
+  allowedNamespaces: { }  # matches all namespaces
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: rosa-capi-pool
+spec:
+  nodePoolName: "nodepool-0"
+  instanceType: "m5.xlarge"
+  subnet: "REPLACE_ME" # public subnet
+  version: "4.19.0-ec.5"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 2

--- a/templates/4_19_tests/rcp-no-cni.yaml
+++ b/templates/4_19_tests/rcp-no-cni.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "capi-no-cni-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "capi-no-cni-test"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "capi-no-cni-test-control-plane"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "capi-no-cni-test"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "capi-no-cni-test-control-plane"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: capi-no-cni-test
+  version:  "4.19.0-ec.5"
+  region: "us-west-2"
+  channelGroup: candidate
+  domainPrefix: capi-test4
+  additionalTags:
+    env: "demo"
+    profile: "hcp"
+    tagKey: "capi-tag"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 3
+  endpointAccess: Public
+  network:
+    machineCIDR: "10.0.0.0/16"
+    networkType: Other
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kms-provider"
+  oidcID: "REPLACE_ME"
+  subnets:
+    - "REPLACE_ME"
+    - "REPLACE_ME"
+  availabilityZones:
+    - "us-west-2b"
+  installerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Worker-Role"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: "default"
+spec:
+  allowedNamespaces: { }  # matches all namespaces
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: rosa-capi-pool
+spec:
+  nodePoolName: "nodepool-0"
+  instanceType: "m5.xlarge"
+  subnet: "REPLACE_ME" # public subnet
+  version: "4.19.0-ec.5"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 2

--- a/templates/4_19_tests/rcp-parallel-node-upgrade.yaml
+++ b/templates/4_19_tests/rcp-parallel-node-upgrade.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "capi-cluster-registry-config-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "capi-cluster-registry-config-test"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "capi-cluster-registry-config-test"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "capi-cluster-registry-config-test"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "capi-cluster-registry-config-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: capi-cluster-registry-config-test
+  version:  "4.19.0-ec.5"
+  region: "us-west-2"
+  channelGroup: candidate
+  domainPrefix: capi-test
+  additionalTags:
+    env: "demo"
+    profile: "hcp"
+    tagKey: "capi-tag"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 3
+  endpointAccess: Public
+  clusterRegistryConfig:
+    allowedRegistriesForImport:
+      - domainName: "trusted-registry.com"
+        insecure: false
+      - domainName: "*.insecure-registry.com"
+        insecure: true
+    registrySources:
+      allowedRegistries:
+        - "allowed-registry.com"
+      insecureRegistries:
+        - "insecure-registry.com"
+  network:
+    machineCIDR: "10.0.0.0/16"
+    networkType: Other
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kms-provider"
+  oidcID: "REPLACE_ME"
+  subnets:
+    - "REPLACE_ME"
+    - "REPLACE_ME"
+  availabilityZones:
+    - "us-west-2b"
+  installerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Worker-Role"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: "default"
+spec:
+  allowedNamespaces: { }  # matches all namespaces
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: rosa-capi-pool
+spec:
+  nodePoolName: "nodepool-0"
+  instanceType: "m5.xlarge"
+  subnet: "REPLACE_ME" # public subnet
+  version: "4.19.0-ec.5"
+  autoscaling:
+    minReplicas: 4
+    maxReplicas: 6
+  updateConfig:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 3

--- a/templates/4_19_tests/rcp-private.yaml
+++ b/templates/4_19_tests/rcp-private.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "capi-private-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "capi-private-test"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "capi-private-test-control-plane"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "capi-private-test"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "capi-private-test-control-plane"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: capi-private-test
+  version:  "4.19.0-ec.5"
+  region: "us-west-2"
+  channelGroup: candidate
+  domainPrefix: capi-test7
+  additionalTags:
+    env: "demo"
+    profile: "hcp"
+    tagKey: "capi-tag"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    autoscaling:
+      minReplicas: 2
+      maxReplicas: 3
+  endpointAccess: Private
+  network:
+    machineCIDR: "10.0.0.0/16"
+    networkType: Other
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/REPLACE_ME-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/REPLACE_ME-kube-system-kms-provider"
+  oidcID: "REPLACE_ME"
+  subnets:
+    - "REPLACE_ME"
+  availabilityZones:
+    - "us-west-2b"
+  installerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/REPLACE_ME-HCP-ROSA-Worker-Role"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterControllerIdentity
+metadata:
+  name: "default"
+spec:
+  allowedNamespaces: { }  # matches all namespaces
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: rosa-capi-pool
+spec:
+  nodePoolName: "nodepool-0"
+  instanceType: "m5.xlarge"
+  subnet: "REPLACE_ME" # public subnet
+  version: "4.19.0-ec.5"
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 2


### PR DESCRIPTION
Adding the rosa-control-plane configuration files used in my 4.19 regression tests.  They're still a work-in-progress.
