### PR TITLE
Fix aws_credentials value.

### DIFF
--- a/tasks/create_capa_manager_bootstrap_credentials.yml
+++ b/tasks/create_capa_manager_bootstrap_credentials.yml
@@ -13,13 +13,17 @@
     ' | base64
   register: aws_credentials
 
-- name: Print AWS Credential information
-  debug:
-    msg: "aws_access_key_id: {{ aws_access_key_id }} aws_secret_access_key: {{ aws_secret_access_key }} region:  {{ region }}  "
+#- name: Print AWS Credential information
+#  debug:
+#    msg: "aws_access_key_id: {{ aws_access_key_id }} aws_secret_access_key: {{ aws_secret_access_key }} region:  {{ region }}  "
+#
+#- name: Print AWS Credentials
+#  debug:
+#    msg: "aws_credentials: {{ aws_credentials.stdout }} "
 
 - name: Create capa-manager-bootstrap-credentials.yaml from template
   vars:
-    aws_credentials: "{{ aws_credentials }}"
+    aws_credentials: "{{ aws_credentials.stdout }}"
   template:
     src: templates/capa-manager-bootstrap-credentials.yaml.j2
     dest: "{{ output_dir }}/capa-manager-bootstrap-credentials.yaml"


### PR DESCRIPTION
Changed to reference `aws_credentials.stdout` instead of `aws_credentials`.