### PR TITLE
capi_assistant - Added create and delete options.

### DIFF
--- a/capi-assistant.yaml
+++ b/capi-assistant.yaml
@@ -27,6 +27,8 @@
           8 - Restart capa-controller-manager deployment.
           9 - Create rosa-creds-secret.
          10 - Show the ROSAControlPlane "ready" status.
+         11 - Create the ROSA_HCP cluster or other resource. (oc apply -f <filename>)
+         12 - Delete the ROSA_HCP cluster or other resource. (oc delete -f <filename>)
       private: no
   tasks:
     - set_fact:
@@ -77,6 +79,14 @@
     - name: Get the ROSAControlPlane.
       include_tasks: tasks/get_rosa_control_plane.yml
       when: selected_action == "10"
+
+    - name: Create the ROSA HCP Cluster
+      include_tasks: tasks/create_rosa_control_plane.yml
+      when: selected_action == "11"
+
+    - name: Delete the ROSA HCP Cluster
+      include_tasks: tasks/delete_rosa_control_plane.yml
+      when: selected_action == "12"
 
     - name: Enable CAPI and CAPA
       include_tasks: tasks/enable_capi_capa.yml

--- a/demo-rosa-hcp.yaml
+++ b/demo-rosa-hcp.yaml
@@ -1,0 +1,117 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: tfitzger-rosa-hcp-demo-test
+  namespace: "ns-rosa-hcp"
+spec:
+  hubAcceptsClient: true
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "tfitzger-rosa-hcp-demo-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: ROSACluster
+    name: "tfitzger-rosa-hcp-demo-test"
+    namespace: "ns-rosa-hcp"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: ROSAControlPlane
+    name: "tfitzger-rosa-hcp-demo-test"
+    namespace: "ns-rosa-hcp"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSACluster
+metadata:
+  name: "tfitzger-rosa-hcp-demo-test"
+  namespace: "ns-rosa-hcp"
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: ROSAControlPlane
+metadata:
+  name: "tfitzger-rosa-hcp-demo-test"
+  namespace: "ns-rosa-hcp"
+spec:
+  rosaClusterName: tfitzger-rosa-hcp-demo-test
+  domainPrefix: rosa-hcp-214d
+  version: "4.18.1"
+  ## The region should match the aws region used to create the VPC and subnets
+  region: "us-west-2"
+  channelGroup: stable
+
+  ## Replace the IAM account roles below with the IAM roles created in the prerequisite steps
+  ## List the IAM account roles using command 'rosa list account-roles'
+  installerRoleARN: "arn:aws:iam::471112697682:role/demo-HCP-ROSA-Installer-Role"
+  supportRoleARN: "arn:aws:iam::471112697682:role/demo-HCP-ROSA-Support-Role"
+  workerRoleARN: "arn:aws:iam::471112697682:role/demo-HCP-ROSA-Worker-Role"
+
+  ## Replace the oidc config below with the oidc config created in the prerequisite steps
+  ## List the oidc config using command `rosa list oidc-providers`
+  oidcID: "2kd71rhid2u2g8t4fmum0503652g6rl6"
+
+  ## Replace IAM operator roles below with the IAM roles created in the prerequisite steps
+  ## List the operator roles using command `rosa list operator-roles --prefix your-prefix`
+  rolesRef:
+    ingressARN: "arn:aws:iam::471112697682:role/demo-openshift-ingress-operator-cloud-credentials"
+    imageRegistryARN: "arn:aws:iam::471112697682:role/demo-openshift-image-registry-installer-cloud-credentials"
+    storageARN: "arn:aws:iam::471112697682:role/demo-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+    networkARN: "arn:aws:iam::471112697682:role/demo-openshift-cloud-network-config-controller-cloud-credentials"
+    kubeCloudControllerARN: "arn:aws:iam::471112697682:role/demo-kube-system-kube-controller-manager"
+    nodePoolManagementARN: "arn:aws:iam::471112697682:role/demo-kube-system-capa-controller-manager"
+    controlPlaneOperatorARN: "arn:aws:iam::471112697682:role/demo-kube-system-control-plane-operator"
+    kmsProviderARN: "arn:aws:iam::471112697682:role/demo-kube-system-kms-provider"
+
+  ## Replace the subnets and availabilityZones with the subnets created in the prerequisite steps
+  subnets:
+    - "subnet-074fb3a779e0135e8"
+    - "subnet-0922e75354ccb5757"
+  availabilityZones:
+    - us-west-2b # ex "us-west-2b"
+  network:
+    machineCIDR: "10.0.0.0/16"
+    podCIDR: "10.128.0.0/14"
+    serviceCIDR: "172.30.0.0/16"
+  defaultMachinePoolSpec:
+    instanceType: "m5.xlarge"
+    autoscaling:
+      maxReplicas: 3
+      minReplicas: 2
+  additionalTags:
+    env: "demo"
+    profile: "hcpt"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: tfitzger-rosa-hcp-demo-test
+  namespace: "ns-rosa-hcp"
+spec:
+  clusterName: "tfitzger-rosa-hcp-demo-test"
+  replicas: 3
+  template:
+    spec:
+      clusterName: "tfitzger-rosa-hcp-demo-test"
+      bootstrap:
+        dataSecretName: ""
+      infrastructureRef:
+        name: tfitzger-rosa-hcp-demo-test
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: ROSAMachinePool
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: ROSAMachinePool
+metadata:
+  name: tfitzger-rosa-hcp-demo-test
+  namespace: "ns-rosa-hcp"
+spec:
+  nodePoolName: "tf-nodepool-t1"
+  instanceType: "m5.xlarge"
+  subnet: "subnet-0922e75354ccb5757" # public subnet
+  version: "4.18.1"

--- a/tasks/create_rosa_control_plane.yml
+++ b/tasks/create_rosa_control_plane.yml
@@ -1,7 +1,26 @@
-- name: Create the ROSAControlPlane
-  vars:
-    stuff_here: "{{ 'stuff' }}"
-  template:
-    src: templates/rosa-control-plane.yaml.j2
-    dest: "{{ output_dir }}/rosa-control-plane.yaml"
+- name: Get the yaml filename for oc apply -f.
+  pause:
+    prompt: "Please enter the yaml file name to apply."
+  register: oc_yaml_file
+
+- name: Display filename entered
+  debug:
+    msg: "oc_yaml_file: {{ oc_yaml_file.user_input }}"
+
+- set_fact:
+    oc_yaml_filename: "{{ oc_yaml_file.user_input }}"
+    fq_oc_yaml_filename: "{{ lookup('env', 'PWD') }}/{{ oc_yaml_file.user_input }}"
+
+- name: Print the fq_oc_yaml_filename
+  debug:
+    msg: "fq_oc_yaml_filename: {{ fq_oc_yaml_filename }}"
+
+- name: OC apply file
+  shell: |
+    oc apply -f {{ fq_oc_yaml_filename }}
+  register: results
+
+- name: Print the results
+  debug:
+    msg: "results: {{ results.stdout }}"
 


### PR DESCRIPTION
Added options for `create` and `delete`.  
```
Choose one of the following:
   1 - Verify MCE CAPI/CAPA environment.
   2 - Configure MCE CAPI/CAPA environment for ROSA_HCP cluster creation.
   3 - Check CAPA/CAPA enabled status.
   4 - Enable CAPA/CAPA.
   5 - Enable ClusterManager auto-import (Add the registrationConfiguration section).
   6 - Apply ClusterRoleBinding changes (cluster-manager-registration-capi).
   7 - Create capa-manager-bootstrap-credentials.
   8 - Restart capa-controller-manager deployment.
   9 - Create rosa-creds-secret.
  10 - Show the ROSAControlPlane "ready" status.
New Options
  11 - Create the ROSA_HCP cluster or other resource. (oc apply -f <filename>)
  12 - Delete the ROSA_HCP cluster or other resource. (oc delete -f <filename>)

```
