### PR TITLE
Added ROSA HCP cluster delete playbook and task.

### DIFF
--- a/capa-cluster-delete-rosa-hcp.yml
+++ b/capa-cluster-delete-rosa-hcp.yml
@@ -1,0 +1,22 @@
+- name: Delete ROSA-HCP Cluster
+  hosts: localhost
+  any_errors_fatal: true
+  vars_files:
+    - vars/vars.yml
+    - vars/user_vars.yml
+  tasks:
+    - set_fact:
+        ocp_user:  "{{ OCP_HUB_CLUSTER_USER }}"
+        ocp_password:  "{{ OCP_HUB_CLUSTER_PASSWORD }}"
+        api_url:  "{{ OCP_HUB_API_URL }}"
+        mce_namespace: "{{ MCE_NAMESPACE }}"
+
+    - name: Prepare ansible runner host
+      include_tasks: tasks/prepare_ansible_runner.yml
+      when: not skip_ansible_runner | bool
+
+    - name: Login OCP
+      include_tasks: tasks/login_ocp.yml
+
+    - name: Delete ROSA HCP cluster
+      include_tasks: tasks/delete_rosa_hcp_cluster.yml

--- a/capi-assistant.yaml
+++ b/capi-assistant.yaml
@@ -9,7 +9,7 @@
       prompt: |
        Choose one of the following:
           1 - Verify MCE CAPI/CAPA environment.
-          2 - Configure MCE CAPI/CAPA environment for ROSA_HCP cluster creation.
+          2 - Configure MCE CAPI/CAPA environment and create a ROSA_HCP cluster.
           3 - Check CAPA/CAPA enabled status.
           4 - Enable CAPA/CAPA.
           5 - Enable ClusterManager auto-import (Add the registrationConfiguration section).

--- a/tasks/delete_rosa_hcp_cluster.yml
+++ b/tasks/delete_rosa_hcp_cluster.yml
@@ -1,0 +1,25 @@
+- name: Get the yaml filename for oc delete -f.
+  pause:
+    prompt: "Please enter the yaml file name for oc delete -f <filename>."
+  register: oc_yaml_file
+
+- name: Display filename entered
+  debug:
+    msg: "oc_yaml_file: {{ oc_yaml_file.user_input }}"
+
+- set_fact:
+    oc_yaml_filename: "{{ oc_yaml_file.user_input }}"
+    fq_oc_yaml_filename: "{{ lookup('env', 'PWD') }}/{{ oc_yaml_file.user_input }}"
+
+- name: Print the fq_oc_yaml_filename
+  debug:
+    msg: "fq_oc_yaml_filename: {{ fq_oc_yaml_filename }}"
+
+- name: OC delete file
+  shell: |
+    oc delete -f {{ fq_oc_yaml_filename }}
+  register: results
+
+- name: Print the results
+  debug:
+    msg: "results: {{ results.stdout }}"


### PR DESCRIPTION
Added playbook/task for deleting a ROSA HCP Cluster.

Prompts the user for the filename to use in the `oc delete -f <filename>` command.

Make sure you're logged into the ROSA stage environment and that you've updated the `vars/user_vars.yml` file with your information.

./run_playbook capa-cluster-delete-rosa-hcp.yml `


  