### PR TITLE
Fixed delete cluster task name, and added commonly used commands to p…

### DIFF
--- a/capi-assistant.yaml
+++ b/capi-assistant.yaml
@@ -79,7 +79,7 @@
       when: selected_action == "11"
 
     - name: Delete the ROSA HCP Cluster
-      include_tasks: tasks/delete_rosa_control_plane.yml
+      include_tasks: tasks/delete_rosa_hcp_cluster.yml
       when: selected_action == "12"
 
     - name: Upgrade the ROSA HCP Cluster

--- a/tasks/enter_shell_command.yml
+++ b/tasks/enter_shell_command.yml
@@ -1,7 +1,22 @@
 
 - name: Get command
   pause:
-    prompt: "Please enter the shell command."
+    prompt: |
+      Please enter a command, or copy and paste one of the commonly used commands below. :-)
+        oc get clustermanager
+        oc get clustermanager -o yaml | grep registrationConfiguration
+        oc get deploy -n multicluster-engine | grep cap
+        oc get clusterrolebinding cluster-manager-registration-capi
+        oc get deploy -n multicluster-engine
+        oc get deploy -n multicluster-engine | grep cap
+        oc get multiclusterengine multiclusterengine
+        oc get pod -n multicluster-engine | grep capa
+        oc get rosacontrolplane
+        oc get secret -n multicluster-engine capa-manager-bootstrap-credentials
+        oc get secret -n multicluster-engine rosa-creds-secret
+        rosa list account-roles
+        rosa list operator-roles
+        kubectl logs -n multicluster-engine <capa_pod_name>
   register: shell_command
 
 - name: Display command entered


### PR DESCRIPTION
Added commonly used commands to prompt. 
....
TASK [Get command] *****************************************************************************************************************************
[Get command]
Please enter a command, or copy and paste one of the commonly used commands below. :-)
  oc get clustermanager
  oc get clustermanager -o yaml | grep registrationConfiguration
  oc get deploy -n multicluster-engine | grep cap
  oc get clusterrolebinding cluster-manager-registration-capi
  oc get deploy -n multicluster-engine
  oc get deploy -n multicluster-engine | grep cap
  oc get multiclusterengine multiclusterengine
  oc get pod -n multicluster-engine | grep capa
  oc get rosacontrolplane
  oc get secret -n multicluster-engine capa-manager-bootstrap-credentials
  oc get secret -n multicluster-engine rosa-creds-secret
  rosa list account-roles
  rosa list operator-roles
  kubectl logs -n multicluster-engine <capa_pod_name>
