### PR TITLE
feat: add inline ResourcesViewer with YAML viewer and improvements

### DIFF
--- a/ui/frontend/src/components/ResourcesViewer.jsx
+++ b/ui/frontend/src/components/ResourcesViewer.jsx
@@ -1,0 +1,242 @@
+import React, { useState, useEffect } from 'react';
+import { ChevronRightIcon, ChevronDownIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { buildApiUrl } from '../config/api';
+import { YamlEditorModal } from './YamlEditorModal.js';
+
+const ResourcesViewer = ({ theme = 'mce' }) => {
+  const [resources, setResources] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedNamespaces, setExpandedNamespaces] = useState(new Set());
+  const [totalCount, setTotalCount] = useState(0);
+  const [selectedResource, setSelectedResource] = useState(null);
+  const [showYamlModal, setShowYamlModal] = useState(false);
+  const [loadingYaml, setLoadingYaml] = useState(false);
+
+  useEffect(() => {
+    fetchResources();
+  }, []);
+
+  const fetchResources = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(buildApiUrl('/api/mce/resources'));
+      const data = await response.json();
+
+      if (data.success && data.resources) {
+        setResources(data.resources);
+        setTotalCount(data.total || data.resources.length || 0);
+      }
+    } catch (error) {
+      console.error('Failed to fetch CAPI resources:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleNamespace = (namespace) => {
+    const newExpanded = new Set(expandedNamespaces);
+    if (newExpanded.has(namespace)) {
+      newExpanded.delete(namespace);
+    } else {
+      newExpanded.add(namespace);
+    }
+    setExpandedNamespaces(newExpanded);
+  };
+
+  const handleResourceClick = async (resource) => {
+    setLoadingYaml(true);
+
+    const requestPayload = {
+      resource_type: resource.type || resource.kind,
+      resource_name: resource.name,
+      namespace: resource.namespace || '',
+    };
+
+    try {
+      const response = await fetch(buildApiUrl('/api/ocp/get-resource-detail'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestPayload),
+      });
+
+      const data = await response.json();
+
+      if (data.success && data.data) {
+        setSelectedResource({
+          yaml_content: data.data,
+          cluster_name: resource.name,
+          feature_type: 'resource-view',
+        });
+        setShowYamlModal(true);
+      } else {
+        console.error('Failed to fetch resource YAML:', data.message || 'Unknown error');
+        alert(`Failed to fetch YAML: ${data.message || 'Unknown error'}`);
+      }
+    } catch (error) {
+      console.error('Error fetching resource YAML:', error);
+      alert(`Error fetching YAML: ${error.message}`);
+    } finally {
+      setLoadingYaml(false);
+    }
+  };
+
+  const groupedResources = resources.reduce((acc, resource) => {
+    const ns = resource.namespace || 'default';
+    if (!acc[ns]) {
+      acc[ns] = [];
+    }
+    acc[ns].push(resource);
+    return acc;
+  }, {});
+
+  const themeColors = theme === 'mce'
+    ? { primary: '#2684FF', hover: '#0065FF', border: 'border-cyan-200' }
+    : { primary: '#8B5CF6', hover: '#7C3AED', border: 'border-purple-200' };
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <div className="text-center py-12">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-cyan-600"></div>
+          <p className="mt-4 text-gray-600">Loading resources...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // If a resource is selected, show YAML viewer inline
+  if (showYamlModal && selectedResource) {
+    return (
+      <div className="space-y-4">
+        {/* Back button */}
+        <button
+          onClick={() => {
+            setShowYamlModal(false);
+            setSelectedResource(null);
+          }}
+          className="flex items-center gap-2 px-4 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+        >
+          ← Back to Resources
+        </button>
+
+        {/* Inline YAML viewer */}
+        <YamlEditorModal
+          isOpen={true}
+          inline={true}
+          onClose={() => {
+            setShowYamlModal(false);
+            setSelectedResource(null);
+          }}
+          yamlData={selectedResource}
+          readOnly={true}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200">
+      {/* Header */}
+      <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="text-xl">🔧</span>
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">Resources</h3>
+            <p className="text-sm text-gray-600">{totalCount} total</p>
+          </div>
+        </div>
+        <button
+          onClick={fetchResources}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm text-white rounded transition-colors"
+          style={{ backgroundColor: themeColors.primary }}
+          onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = themeColors.hover)}
+          onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = themeColors.primary)}
+        >
+          <ArrowPathIcon className="h-4 w-4" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Resources List */}
+      <div className="px-6 py-4">
+        {Object.keys(groupedResources).length === 0 ? (
+          <div className="text-center py-12 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg">
+            <p className="text-gray-600">No CAPI/CAPA resources found</p>
+            <p className="text-sm text-gray-500 mt-2">Resources will appear here after provisioning clusters</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {Object.entries(groupedResources).map(([namespace, nsResources]) => (
+              <div key={namespace} className="border border-gray-200 rounded-lg overflow-hidden">
+                {/* Namespace Header */}
+                <button
+                  onClick={() => toggleNamespace(namespace)}
+                  className="w-full px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors flex items-center justify-between"
+                >
+                  <div className="flex items-center gap-2">
+                    {expandedNamespaces.has(namespace) ? (
+                      <ChevronDownIcon className="h-4 w-4 text-gray-600" />
+                    ) : (
+                      <ChevronRightIcon className="h-4 w-4 text-gray-600" />
+                    )}
+                    <span className="font-medium text-gray-900">{namespace}</span>
+                  </div>
+                  <span className="px-2 py-1 bg-white rounded text-xs font-medium text-gray-700">
+                    {nsResources.length}
+                  </span>
+                </button>
+
+                {/* Resource Items */}
+                {expandedNamespaces.has(namespace) && (
+                  <div className="divide-y divide-gray-100">
+                    {nsResources.map((resource, idx) => (
+                      <button
+                        key={idx}
+                        onClick={() => handleResourceClick(resource)}
+                        disabled={loadingYaml}
+                        className="w-full px-4 py-3 hover:bg-gray-50 transition-colors text-left disabled:opacity-50"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-3">
+                            <div className="flex items-center gap-2">
+                              <span className="text-sm font-medium text-gray-900">
+                                {resource.name}
+                              </span>
+                              <span className="px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs font-medium">
+                                {resource.type || resource.kind}
+                              </span>
+                            </div>
+                          </div>
+                          {resource.status && (
+                            <span
+                              className={`px-2 py-1 rounded text-xs font-medium ${
+                                resource.status === 'Ready' || resource.status === 'Running'
+                                  ? 'bg-green-100 text-green-700'
+                                  : resource.status === 'Pending'
+                                  ? 'bg-yellow-100 text-yellow-700'
+                                  : 'bg-gray-100 text-gray-700'
+                              }`}
+                            >
+                              {resource.status}
+                            </span>
+                          )}
+                        </div>
+                        {resource.age && (
+                          <div className="text-xs text-gray-500 mt-1">
+                            Age: {resource.age}
+                          </div>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ResourcesViewer;

--- a/ui/frontend/src/components/YamlEditorModal.js
+++ b/ui/frontend/src/components/YamlEditorModal.js
@@ -8,6 +8,7 @@ import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
   DocumentTextIcon,
+  DocumentDuplicateIcon,
 } from '@heroicons/react/24/outline';
 
 export function YamlEditorModal({ isOpen, onClose, onProvision, yamlData, readOnly = false, inline = false }) {
@@ -16,6 +17,7 @@ export function YamlEditorModal({ isOpen, onClose, onProvision, yamlData, readOn
   const [validationError, setValidationError] = useState(null);
   const [showDiff, setShowDiff] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
+  const [copySuccess, setCopySuccess] = useState(false);
   const textareaRef = useRef(null);
 
   // Initialize YAML content when modal opens
@@ -102,6 +104,17 @@ export function YamlEditorModal({ isOpen, onClose, onProvision, yamlData, readOn
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+  };
+
+  // Copy YAML to clipboard
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(editedYaml);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy YAML:', err);
+    }
   };
 
   // Generate simple diff view
@@ -203,6 +216,18 @@ export function YamlEditorModal({ isOpen, onClose, onProvision, yamlData, readOn
             >
               <ArrowDownTrayIcon className="h-4 w-4" />
               Download
+            </button>
+            <button
+              onClick={handleCopy}
+              className={`flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-lg transition-colors text-sm font-medium ${
+                copySuccess
+                  ? 'bg-green-50 text-green-700 border-green-300'
+                  : 'text-gray-700 hover:bg-gray-50'
+              }`}
+              title="Copy YAML to clipboard"
+            >
+              <DocumentDuplicateIcon className="h-4 w-4" />
+              {copySuccess ? 'Copied!' : 'Copy'}
             </button>
             <button
               onClick={handleReset}

--- a/ui/frontend/src/components/sections/TaskSummarySection.jsx
+++ b/ui/frontend/src/components/sections/TaskSummarySection.jsx
@@ -291,9 +291,12 @@ const TaskSummarySection = ({ theme = 'mce', environment }) => {
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  clearRecentOperations();
+                  if (window.confirm(`Are you sure you want to clear all ${filteredOperations.length} task(s)? This cannot be undone.`)) {
+                    clearRecentOperations();
+                  }
                 }}
                 className="bg-red-500/30 hover:bg-red-500/50 text-white px-3 py-1.5 rounded-lg transition-colors duration-200 flex items-center space-x-1 text-sm font-medium"
+                title="Clear all tasks from history"
               >
                 <TrashIcon className="h-4 w-4" />
                 <span>Clear</span>

--- a/ui/frontend/src/pages/CAPADashboard.jsx
+++ b/ui/frontend/src/pages/CAPADashboard.jsx
@@ -14,6 +14,7 @@ import { RosaProvisionModal } from '../components/RosaProvisionModal';
 import TestSuiteDashboard from '../components/sections/TestSuiteDashboard';
 import TestSuiteSection from '../components/sections/TestSuiteSection';
 import HelmChartTestDashboard from '../components/sections/HelmChartTestDashboard';
+import ResourcesViewer from '../components/ResourcesViewer';
 import {
   AppProvider,
   useApiStatusContext,
@@ -1326,68 +1327,68 @@ const CAPADashboardContent = () => {
 
               {/* Components Lists - Side by Side */}
               <div className="grid grid-cols-2 gap-4">
+                {/* CAPI/CAPA Components List */}
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-700 mb-2">CAPI/CAPA</h3>
+                  <div className="space-y-2 max-h-40 overflow-y-auto">
+                    {(() => {
+                      const capiComponents = mceFeatures
+                        .filter(component =>
+                          component.name === 'cluster-api' ||
+                          component.name?.startsWith('cluster-api-provider-')
+                        )
+                        .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+
+                      return capiComponents.length === 0 ? (
+                        <div className="text-center py-8 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg">
+                          <p className="text-sm text-gray-600">No CAPI components configured</p>
+                        </div>
+                      ) : (
+                        capiComponents.map((component, index) => (
+                          <div
+                            key={index}
+                            className="flex items-center justify-between py-1 px-2 text-xs hover:bg-gray-50"
+                          >
+                            <span className="truncate">{component.name}</span>
+                            <span className={`ml-2 ${component.enabled ? 'text-green-600' : 'text-red-600'}`}>
+                              {component.enabled ? '✓' : '✕'}
+                            </span>
+                          </div>
+                        ))
+                      );
+                    })()}
+                  </div>
+                </div>
+
                 {/* Hypershift Components List */}
                 <div>
-                <h3 className="text-sm font-semibold text-gray-700 mb-2">Hypershift</h3>
-                <div className="space-y-2 max-h-40 overflow-y-auto">
-                  {(() => {
-                    const hypershiftComponents = mceFeatures
-                      .filter(component => component.name?.includes('hypershift'))
-                      .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+                  <h3 className="text-sm font-semibold text-gray-700 mb-2">Hypershift</h3>
+                  <div className="space-y-2 max-h-40 overflow-y-auto">
+                    {(() => {
+                      const hypershiftComponents = mceFeatures
+                        .filter(component => component.name?.includes('hypershift'))
+                        .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
 
-                    return hypershiftComponents.length === 0 ? (
-                      <div className="text-center py-8 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg">
-                        <p className="text-sm text-gray-600">No Hypershift components configured</p>
-                      </div>
-                    ) : (
-                      hypershiftComponents.map((component, index) => (
-                        <div
-                          key={index}
-                          className="flex items-center justify-between py-1 px-2 text-xs hover:bg-gray-50"
-                        >
-                          <span className="truncate">{component.name}</span>
-                          <span className={`ml-2 ${component.enabled ? 'text-green-600' : 'text-red-600'}`}>
-                            {component.enabled ? '✓' : '✕'}
-                          </span>
+                      return hypershiftComponents.length === 0 ? (
+                        <div className="text-center py-8 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg">
+                          <p className="text-sm text-gray-600">No Hypershift components configured</p>
                         </div>
-                      ))
-                    );
-                  })()}
+                      ) : (
+                        hypershiftComponents.map((component, index) => (
+                          <div
+                            key={index}
+                            className="flex items-center justify-between py-1 px-2 text-xs hover:bg-gray-50"
+                          >
+                            <span className="truncate">{component.name}</span>
+                            <span className={`ml-2 ${component.enabled ? 'text-green-600' : 'text-red-600'}`}>
+                              {component.enabled ? '✓' : '✕'}
+                            </span>
+                          </div>
+                        ))
+                      );
+                    })()}
+                  </div>
                 </div>
-              </div>
-
-              {/* CAPI/CAPA Components List */}
-              <div>
-                <h3 className="text-sm font-semibold text-gray-700 mb-2">CAPI/CAPA</h3>
-                <div className="space-y-2 max-h-40 overflow-y-auto">
-                  {(() => {
-                    const capiComponents = mceFeatures
-                      .filter(component =>
-                        component.name === 'cluster-api' ||
-                        component.name?.startsWith('cluster-api-provider-')
-                      )
-                      .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
-
-                    return capiComponents.length === 0 ? (
-                      <div className="text-center py-8 bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg">
-                        <p className="text-sm text-gray-600">No CAPI components configured</p>
-                      </div>
-                    ) : (
-                      capiComponents.map((component, index) => (
-                        <div
-                          key={index}
-                          className="flex items-center justify-between py-1 px-2 text-xs hover:bg-gray-50"
-                        >
-                          <span className="truncate">{component.name}</span>
-                          <span className={`ml-2 ${component.enabled ? 'text-green-600' : 'text-red-600'}`}>
-                            {component.enabled ? '✓' : '✕'}
-                          </span>
-                        </div>
-                      ))
-                    );
-                  })()}
-                </div>
-              </div>
               </div>
             </div>
 
@@ -1767,10 +1768,9 @@ const CAPADashboardContent = () => {
             {/* Title */}
             <h2 className="text-2xl font-bold text-blue-900">Provision Resources</h2>
 
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <p className="text-gray-600 mb-4">View and manage CAPI/CAPA Kubernetes resources.</p>
-              <div className="text-sm text-gray-500">Resources section coming soon...</div>
-            </div>
+            <p className="text-gray-600 mb-4">View and manage CAPI/CAPA Kubernetes resources.</p>
+
+            <ResourcesViewer theme="mce" />
           </div>
         );
 


### PR DESCRIPTION
## Summary
- Add new inline ResourcesViewer component for Provision Resources section
- Enhance YamlEditorModal with copy-to-clipboard functionality
- Convert YAML viewer from modal to inline display
- Improve component layout in Verify section
- Add confirmation dialog for task clearing

## Changes

### ResourcesViewer Component
- Groups CAPI/CAPA resources by namespace with expand/collapse functionality
- Displays resource name, type/kind, status, and age
- Click on any resource to view full YAML inline
- Refresh button to reload resources from API
- Integrates with existing `/api/mce/resources` endpoint

### YAML Viewer Enhancements
- Added Copy button with success feedback ("Copied!" confirmation for 2 seconds)
- Converted from modal popup to inline display
- Added "Back to Resources" button for navigation
- Maintains all existing functionality (download, reset, diff view)

### UI Improvements
- Moved CAPI/CAPA components to left column in Verify section
- Moved Hypershift components to right column
- Better visual hierarchy matching project focus on CAPI/CAPA

### Task Management
- Added confirmation dialog before clearing task history
- Shows count of tasks to be cleared
- Prevents accidental data loss

## Test Plan
- [x] Verify ResourcesViewer displays resources grouped by namespace
- [x] Click on resources to view YAML inline
- [x] Test Copy button copies YAML to clipboard
- [x] Verify "Back to Resources" navigation works
- [x] Confirm component order swap in Verify section
- [x] Test task clearing confirmation dialog

## Screenshots
ResourcesViewer showing resources by namespace with inline YAML viewer and Copy button functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)